### PR TITLE
xtb version correction

### DIFF
--- a/environment_qm.yml
+++ b/environment_qm.yml
@@ -27,7 +27,8 @@ dependencies:
   # special
   - libecpint
   - psi4
-  - xtb
+    # 6.7.1 is buggy
+  - xtb==6.6.1
 
   - pip:
     - cclib


### PR DESCRIPTION
xtb 6.7.1 (the default in conda-forge at the moment) is buggy. xtb 6.6.1 is okay, so we specify this version here.