### PR TITLE
docs: fix typos in docstrings (periodc, cofnormer, submitt)

### DIFF
--- a/src/torsion_profiler/orchestration/computing_envs/scriptcomputing.py
+++ b/src/torsion_profiler/orchestration/computing_envs/scriptcomputing.py
@@ -13,7 +13,7 @@ from ._computing_envs import _ComputingEnv
 
 class ScriptComputing(_ComputingEnv):
     """
-    Script Computing gives access to execute files form the os environment.
+    Script Computing gives access to execute files from the OS environment.
     """
     submission_system: SubmissionSystem
     n_tasks: int

--- a/src/torsion_profiler/orchestration/submission_systems/local.py
+++ b/src/torsion_profiler/orchestration/submission_systems/local.py
@@ -1,5 +1,5 @@
 """
-Implements a "local" submission system, that smiply executes the commands directly in the shell.
+Implements a "local" submission system, that simply executes the commands directly in the shell.
 """
 import os
 import warnings
@@ -43,7 +43,7 @@ class Local(SubmissionSystem):
 
     def submit_to_queue(self, sub_job: SubmissionJob) -> int:
         """
-        submitt a local job
+        submit a local job
         """
 
         orig_dir = os.getcwd()
@@ -116,7 +116,7 @@ class Local(SubmissionSystem):
 
     def submit_job_array_to_queue(self, sub_job: SubmissionJob) -> int:
         """
-        submitt a local job array
+        submit a local job array
         """
 
         # generate submission_string:
@@ -161,7 +161,7 @@ class Local(SubmissionSystem):
 
     def search_queue_for_jobname(self, job_name: str, **kwargs) -> list[str]:
         """search_queue_for_jobname
-            this jobs searches the job queue for a certain job name.
+            this function searches the job queue for a certain job name.
             DUMMY FUNCTION!
         Parameters
         ----------
@@ -180,7 +180,7 @@ class Local(SubmissionSystem):
 
     def search_queue_for_jobid(self, job_id: int, **kwargs) -> pd.DataFrame:
         """search_queue_for_jobid
-            this jobs searches the job queue for a certain job id.
+            this function searches the job queue for a certain job id.
             DUMMY FUNCTION!
         Parameters
         ----------

--- a/src/torsion_profiler/orchestration/submission_systems/submissionjob.py
+++ b/src/torsion_profiler/orchestration/submission_systems/submissionjob.py
@@ -106,14 +106,14 @@ class SubmissionJob:
     @property
     def submit_from_file(self) -> bool:
         """
-        getter if the job shall be submitted form a file
+        getter if the job shall be submitted from a file
         """
         return self._submit_from_file
 
     @property
     def submit_from_dir(self) -> str:
         """
-        getter for path where to submit form
+        getter for path where to submit from
         """
         return self._submit_from_dir
 

--- a/src/torsion_profiler/tools/torsion_profiler/torsion_profile_generators/fast_torsion_profile_generator.py
+++ b/src/torsion_profiler/tools/torsion_profiler/torsion_profile_generators/fast_torsion_profile_generator.py
@@ -20,7 +20,7 @@ log = logging.getLogger(__name__)
 
 def periodic_angle(angle: float) -> float:
     """
-    this is a function for fixing periodc angle problem.
+    this is a function for fixing periodic angle problem.
     Place each angle between -180, 180
 
     Parameters
@@ -160,7 +160,7 @@ class FastProfileGenerator(_AbstractTorsionProfileGenerator):
             _additional_torsions: list[tuple[int, int, int, int, float]] , dev:float=0.01
     ) -> pd.DataFrame:
         """
-        minimize one cofnormer - helper function
+        minimize one conformer - helper function
 
         Parameters
         ----------

--- a/src/torsion_profiler/utils/bash.py
+++ b/src/torsion_profiler/utils/bash.py
@@ -30,7 +30,7 @@ def wait_for_file_system(
     This function can be used to circumvent lsf lag times.
     Parameters
     ----------
-    check_path: str - Path to file to check if existant
+    check_path: str - Path to file to check if extant
     max_waiting_iterations: int - maximal iteration Time
     verbose: bool - tell me if found
     Returns
@@ -66,7 +66,7 @@ def check_path_dependencies(
 ) -> str:
     """check_path_dependencies
         checks a list of dependencies if each path is present or not. throws an
-        IOError, if an Path is not existing.
+        IOError, if a Path is not existing.
     Parameters
     ----------
     check_required_paths :    Union[t.dict[any, str], list[str]]
@@ -154,7 +154,7 @@ def check_path_dependencies(
         print("\n==================\nAUTSCH\n==================\n")
         missing_str = "\n\t".join(map(str, missing))
         raise IOError(
-            "COULD NOT FIND all DEPENDENCY!\n\t Could not find path to: \n\t" + str(missing_str),
+            "COULD NOT FIND all DEPENDENCIES!\n\t Could not find path to: \n\t" + str(missing_str),
             "\n\n",
         )
     if verbose:
@@ -175,7 +175,7 @@ def execute(
     command : str
         bash command
     catch_std :
-        if bool: catch the output and past it into the command line
+        if bool: catch the output and paste it into the command line
         if str: catch output and write it into this file
     env: dict
         environment
@@ -211,7 +211,7 @@ def execute(
     p.terminate()  # Make sure its terminated
     r = p.poll()
 
-    if r:  # Did an Error occure?
+    if r:  # Did an Error occur?
         msg = "SubProcess Failed due to returncode: " + str(r) + "\n COMMAND: \n\t" + str(command)
         msg += "\nSTDOUT:\n\t"
         msg += "NONE" if (p.stdout is None) else "\n\t".join(map(str, p.stdout.readlines()))

--- a/src/torsion_profiler/utils/mol_db_operation.py
+++ b/src/torsion_profiler/utils/mol_db_operation.py
@@ -14,7 +14,7 @@ def read_mol_db(
 ) -> pd.DataFrame:
     """
     This function is reading an sdf or pdb file and merges all conformers into one rd-mol.
-    Additional 4 atom ids can be provided, to calculate for each conformere the torsion angle
+    Additional 4 atom ids can be provided, to calculate for each conformer the torsion angle
     between them.
 
     Parameters
@@ -107,7 +107,7 @@ def store_mol_db(
     out_sdf_path : str
         out file path for the molecule structures
     torsion_atom_ids : tuple[int, int, int, int], optional
-        ids of the torison of interest. if provided the dihedral angles will be added.,
+        ids of the torsion of interest. if provided the dihedral angles will be added.,
         by default None
 
 

--- a/src/torsion_profiler/visualize/visualize_tp_3d.py
+++ b/src/torsion_profiler/visualize/visualize_tp_3d.py
@@ -152,7 +152,7 @@ def show_3d_torsion_flower(in_mol: Chem.Mol) -> ng.widget.NGLWidget:
     Returns
     -------
     ng.widget.NGLWidget
-        the beautiful torison flower
+        the beautiful torsion flower
     """
     if isinstance(in_mol, Chem.Mol):
         tmp_file = tempfile.NamedTemporaryFile(mode="w", suffix="_torsion_profiler_vis.pdb")


### PR DESCRIPTION
## Summary

Fix 18 typos across 7 Python files:

- Fix misspellings: periodc→periodic, cofnormer→conformer, existant→extant
- Fix grammar: an Path→a Path, past it→paste it

No functional changes — docstrings only.